### PR TITLE
Fixes gh profile case error

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -50,7 +50,7 @@ teams:
       - jeefy
     members:
       - amye
-      - cmierly
+      - Cmierly
       - RobertKielty
       - krook
   - name: cod-resource-management


### PR DESCRIPTION
The CMierly profile was spelled incorrectly.

GH Profiles are case sensitive, this changes cmierly to Cmierly