### PR TITLE
Update wg-green-reviews repo permissions

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -14,8 +14,8 @@ repositories:
       tag-env-leads: admin
       cncf-project-ops: admin
     external_collaborators:
-      nikimanoledaki: maintain
-      guidemetothemoon: maintain
+      nikimanoledaki: admin
+      guidemetothemoon: admin
   - name: wg-higher-ed
     displayName: WG Higher Education
     teams:


### PR DESCRIPTION
This pr updates the permissions of the WG Green Reviews chairs to Admin. This allows the chairs to update repository secrets etc. which we need to trigger pipelines. 

cc https://github.com/cncf-tags/green-reviews-tooling/pull/6