### PR TITLE
Add bart0sh and  klueska as cod-resource-management members

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -77,6 +77,7 @@ teams:
     maintainers:
       - crosbymichael
     members:
+      - bart0sh
       - elezar
       - kad
       - klihub

--- a/access-control.yaml
+++ b/access-control.yaml
@@ -81,6 +81,7 @@ teams:
       - elezar
       - kad
       - klihub
+      - klueska
       - marquiz
       - zvonkok
   - name: wg-artifacts-leads


### PR DESCRIPTION
This PR adds @bart0sh as a COD resource managment member for the container-orchestrated-devices repo.