### PR TITLE
Remove max as chair from tag env team cncf-tags

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -55,7 +55,6 @@ teams:
     members:
       - catblade
       - guidemetothemoon
-      - mkorbi
       - saiyam1814
   - name: tag-env-wg-green-reviews-leads
     displayName: CNCF TAG Environmental Sustainability Working Group Green Reviews Chairs and Tech Leads


### PR DESCRIPTION
This PR updates the access list for TAG ENV. Max stepped down as Chair for TAG ENV. ref: https://github.com/cncf/tag-env-sustainability/issues/531


cc @RobertKielty 