### PR TITLE
Fix CLOWarden warnings

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -73,7 +73,6 @@ teams:
     maintainers:
       - jeefy
     members:
-      - Cmierly
       - RobertKielty
       - krook
   - name: cod-resource-management-rs


### PR DESCRIPTION
It looks like @Cmierly has removed herself from the CNCF org. Given that she's still in the config file, CLOWarden is trying to invite her back (she cancelled the new invitations). This PR removes her from the configuration file so that she doesn't receive any more invitations.

/cc @RobertKielty