### PR TITLE
Add cdesiniotis to COD Resource Management

### DIFF
--- a/access-control.yaml
+++ b/access-control.yaml
@@ -93,6 +93,7 @@ teams:
       - klueska
       - marquiz
       - zvonkok
+      - cdesiniotis
   - name: wg-artifacts-leads
     displayName: Working Group Artifacts
     maintainers:


### PR DESCRIPTION
This change adds [cdesiniotis](https://github.com/cdesiniotis) to the COD Resource Management group.

This is required for development / maintenance of the CDI specification and related tooling.